### PR TITLE
Distinct iteration paths for Lazy SMP threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -387,9 +387,29 @@ void Thread::search() {
   // Iterative deepening loop until requested to stop or target depth reached
   while (++rootDepth < DEPTH_MAX && !Signals.stop && (!Limits.depth || rootDepth <= Limits.depth))
   {
-      // Set up the new depth for the helper threads
+      // Set up the new depth for the helper threads skipping in average each
+      // 2nd ply (using a half density map similar to a Hadamard matrix).
       if (!isMainThread)
-          rootDepth = std::min(DEPTH_MAX - ONE_PLY, Threads.main()->rootDepth + Depth(int(2.2 * log(1 + this->idx))));
+      {
+          int d = rootDepth + rootPos.game_ply();
+
+          if (idx <= 6 || idx > 24)
+          {
+              if (((d + idx) >> (msb(idx + 1) - 1)) % 2)
+                  continue;
+          }
+          else
+          {
+              // Table of values of 6 bits with 3 of them set
+              static const int HalfDensityMap[] = {
+                      0x07, 0x0b, 0x0d, 0x0e, 0x13, 0x16, 0x19, 0x1a, 0x1c,
+                      0x23, 0x25, 0x26, 0x29, 0x2c, 0x31, 0x32, 0x34, 0x38
+              };
+
+              if ((HalfDensityMap[idx - 7] >> (d % 6)) & 1)
+                  continue;
+          }
+      }
 
       // Age out PV variability metric
       if (isMainThread)


### PR DESCRIPTION
STC 5+0.1, threads 7
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 6026 W: 1047 L: 901 D: 4078

LTC: 20+0.2, threads 7
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 19739 W: 2910 L: 2721 D: 14108

STC 5+0.1, threads 20
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 2493 W: 462 L: 331 D: 1700

LTC 30+0.3, threads 20
ELO: 8.86 +-3.7 (95%) LOS: 100.0%
Total: 8000 W: 1076 L: 872 D: 6052

Bench: 8012530

Resolves #525